### PR TITLE
Added dynamic urls for actions

### DIFF
--- a/src/Zone.Episerver.PropertyViewer/ClientResources/property-viewer.js
+++ b/src/Zone.Episerver.PropertyViewer/ClientResources/property-viewer.js
@@ -6,11 +6,12 @@ $(function() {
 	var $jsTree = $("#jsTree");
 	var $propertyList = $("#propertyList");
 	var $blockPropertyList = $("#blockPropertyList");
+    var config = window.propertyViewerConfig;
 
 	$jsTree.jstree({
 		"core": {
 			"data": {
-				"url": buildUrl("GetContentTree"),
+				"url": config.getContentTreeUrl,
 				"dataType": "json",
 				"data": function(node) {
 					// jstree requests # for root of tree
@@ -27,7 +28,7 @@ $(function() {
 			showLoader(true);
 			pageId.value = data.node.id;
 
-			$.ajax(buildUrl("GetProperties") + "?pageId=" + data.node.id)
+			$.ajax(config.getPropertiesUrl + "?pageId=" + data.node.id)
 				.done(function(data) {
 					$propertyList.html(data);
 					hideLoader(false);
@@ -40,7 +41,7 @@ $(function() {
 			clearResults();
 			clearBlockProperties();
 			showLoader(true);
-			$.ajax(buildUrl("GetPropertyValues") + "?pageId=" +
+			$.ajax(config.getPropertyValuesUrl + "?pageId=" +
 					pageId.value +
 					"&propertyname=" +
 					this.value)
@@ -59,7 +60,7 @@ $(function() {
 		function() {
 			clearResults();
 			showLoader(true);
-			$.ajax(buildUrl("GetBlockPropertyValues") + "?pageId=" +
+			$.ajax(config.getBlockPropertyValuesUrl + "?pageId=" +
 					pageId.value +
 					"&propertyname=" +
 					$propertyList.find("select").val() +
@@ -70,10 +71,6 @@ $(function() {
 					hideLoader(false);
 				});
 		});
-
-    function buildUrl(action) {
-        return "/EPiServer/Zone.Episerver.PropertyViewer/PropertyViewer/" + action + "/";
-    }
 
 	function clearAll() {
 		clearProperties();

--- a/src/Zone.Episerver.PropertyViewer/Properties/AssemblyInfo.cs
+++ b/src/Zone.Episerver.PropertyViewer/Properties/AssemblyInfo.cs
@@ -30,4 +30,4 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.1.0")]
+[assembly: AssemblyVersion("1.1.*")]

--- a/src/Zone.Episerver.PropertyViewer/Views/PropertyViewer/Index.cshtml
+++ b/src/Zone.Episerver.PropertyViewer/Views/PropertyViewer/Index.cshtml
@@ -14,6 +14,16 @@
     <script src="https://ajax.aspnetcdn.com/ajax/jQuery/jquery-3.3.1.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.8/jstree.min.js"></script>
     <script src="@Paths.ToClientResource("Zone.Episerver.PropertyViewer", "ClientResources/property-viewer.js")"></script>
+    <script>
+        window.propertyViewerConfig =
+        {
+            indexUrl: '@Url.Action("Index")',
+            getContentTreeUrl: '@Url.Action("GetContentTree")',
+            getPropertiesUrl: '@Url.Action("GetProperties")',
+            getPropertyValuesUrl: '@Url.Action("GetPropertyValues")',
+            getBlockPropertyValuesUrl: '@Url.Action("GetBlockPropertyValues")'
+        };
+    </script>
 }
 
 <div class="epi-contentContainer">

--- a/src/Zone.Episerver.PropertyViewer/Zone.Episerver.PropertyViewer.nuspec
+++ b/src/Zone.Episerver.PropertyViewer/Zone.Episerver.PropertyViewer.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Zone.Episerver.PropertyViewer</id>
-    <version>1.1.0</version>
+    <version>1.1.1-develop</version>
     <title>Zone.Episerver.PropertyViewer</title>
     <authors>Ollie Philpott</authors>
     <owners>Zone</owners>


### PR DESCRIPTION
Fixes bug where content tree doesn't load if a custom url is used for protected modules (i.e. different from /episerver/)